### PR TITLE
Fixed syntax error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,5 +120,5 @@ exports.decorateConfig = config => {
         background-color: ${tabActiveBorder};
       }
     `
-  }
-});
+  })
+};


### PR DESCRIPTION
_Apologetically, I don't do much contributing to other people's code-bases. So if there is a standard protocol that I am not familiar with, please do let me know so I can do better next time._

## PR Motivation
![ERR!](https://raw.githubusercontent.com/colshacol/foreign-storage/master/images/Screenshot%20from%202017-06-01%2023-07-47.png)

I installed `hyperterm-electron-highlighter` this morning and it didn't work so I moved on with my unnecessary tooling business. When I installed the new `hyper` AppImage, I noticed it said there was a missing `)` in `hyperterm-electron-highlighter`. After making this fix locally, it began working.

Also, I question my fix here. It seems as though nobody else has had this problem, and your `./index.js` that I edited hasn't been touched in months. So maybe I am missing something.

Either way. I hope this helps. I wish the code I contributed could have been more complex to really show off my mad skills, but... I suppose we take what we can get!